### PR TITLE
Implement swmm-stride using c-code

### DIFF
--- a/pyswmm/__init__.py
+++ b/pyswmm/__init__.py
@@ -28,3 +28,8 @@ __all__ = [
     Link, Links, LidControls, LidGroups, Node, Nodes, Subcatchment, Subcatchments, Simulation,
     SystemStats, RainGages, RainGage, Output
 ]
+
+
+# Monkey Patching
+import pyswmm._monkey_patch
+pyswmm._monkey_patch.patch()

--- a/pyswmm/_monkey_patch.py
+++ b/pyswmm/_monkey_patch.py
@@ -16,7 +16,12 @@ import warnings
 
 import packaging.version
 from swmm.toolkit import __version__ as _tk_version
+from swmm.toolkit import solver
+from pyswmm.swmm5 import PySWMM
 
+# %% ###########################
+# region MonkeyPatchTypes ######
+################################
 class ToolkitVersionException(Exception):
     pass
 
@@ -31,6 +36,7 @@ class _monkey_patch:
             self,
             function_name: str,
             swmm_toolkit_minimum_version: str,
+            object_to_patch: object,
             alternative_function: Callable = None,
             warning_message: str = None,
         ):
@@ -38,6 +44,7 @@ class _monkey_patch:
         self.swmm_toolkit_minimum_version = swmm_toolkit_minimum_version
         self._alternative_function = alternative_function
         self.warning_message = warning_message
+        self._object_to_patch = object_to_patch
 
     def _toolkit_error_func(self,*args,**kwargs):
         """A default monkey patch function that raises a toolkit version error"""        
@@ -63,22 +70,74 @@ class _monkey_patch:
         There might be a case where we don't necesarily want to patch the function but only
         want to issue a warning at runtime (e.g. if api doen't change but as expanded capabilities in a newer version)
         """
-        True if self._alternative_function is not None else False
+        return True if self._alternative_function is not None else False
     
-    def patch(self,module):
+    def patch(self):
         """Apply monkey patch to module if toolkit version is less than minimum version"""
         if packaging.version.parse(_tk_version) < packaging.version.parse(self.swmm_toolkit_minimum_version):
             if self.warning_message is not None:
                 warnings.warn(self.warning_message,MonkeyPatchWarning)
             
-            if not hasattr(module,self.function_name) or self.force_patch:
-                setattr(module,self.function_name,self.alt_function) 
+            if not hasattr(self._object_to_patch,self.function_name) or self.force_patch:
+                setattr(self._object_to_patch,self.function_name,self.alt_function) 
+
+# endregion MonkeyPatchTypes ####
+
+# %% ##############################
+# region PySWMMObjectPatches ######
+###################################
+
+def swmm_stride(self, advanceSeconds):
+    """
+    This function allows for user defined stride length to advance
+    the model simulation by a defined time.  This is useful when control
+    rules are managed externally by PySWMM. Instead of evaluating rules
+    every routing step, instead the simulation can be advanced further
+    in time before the PySWMM can intervene. When a 0 is returned, the
+    simulation period has reached the end.
+
+    :param int advanceSeconds: Number seconds to advance the simulation
+                                forward.
+    :return: Current simulation time after a stride in decimal days (float)
+    :rtype: float
+
+    Examples:
+
+    >>> swmm_model = PySWMM(r'\\.inp',r'\\.rpt',r'\\.out')
+    >>> swmm_model.swmm_open()
+    >>> swmm_model.swmm_start(True)
+    >>> while(True):
+    ...     time = swmm_model.swmm_stride(600)
+    ...     if (time <= 0.0): break
+    >>>
+    >>> swmm_model.swmm_end()
+    >>> swmm_model.swmm_report()
+    >>> swmm_model.swmm_close()
+    """
+    ctime = self.curSimTime
+    secPday = 3600.0 * 24.0
+    advanceDays = advanceSeconds / secPday
+    eps = advanceDays * 0.00001
+    elapsed_time = 0
+
+    while self.curSimTime <= ctime + advanceDays - eps:
+        elapsed_time = solver.swmm_step()
+        if elapsed_time == 0:
+            return 0.0
+        self.curSimTime = elapsed_time
+
+    return elapsed_time
+
+# endregion PySWMMObjectPatches ####
 
 
-_solver_monkey_patches = [
-    _monkey_patch(function_name = "swmm_hotstart",swmm_toolkit_minimum_version="0.15.0"),
+# Patches
+_patches = [
+    _monkey_patch(function_name = "swmm_hotstart",swmm_toolkit_minimum_version="0.15.0",object_to_patch=solver),
+    _monkey_patch(function_name = "swmm_stride" ,swmm_toolkit_minimum_version="0.15.0",object_to_patch=PySWMM,alternative_function=swmm_stride),
+
 ]
-
-def _patch_solver(solver_module):
-    for monkey_patch in _solver_monkey_patches:        
-        monkey_patch.patch(solver_module)
+def patch():    
+    # patch solver
+    for monkey_patch in _patches:        
+        monkey_patch.patch()

--- a/pyswmm/swmm5.py
+++ b/pyswmm/swmm5.py
@@ -22,11 +22,6 @@ from swmm.toolkit import solver
 # Local imports
 import pyswmm.toolkitapi as tka
 
-# Monkey Patching
-from pyswmm._monkey_patch import _patch_solver
-_patch_solver(solver)
-
-
 class SWMMException(Exception):
     """Custom exception class for SWMM errors."""
 
@@ -308,19 +303,9 @@ class PySWMM(object):
         >>> swmm_model.swmm_report()
         >>> swmm_model.swmm_close()
         """
-        ctime = self.curSimTime
-        secPday = 3600.0 * 24.0
-        advanceDays = advanceSeconds / secPday
-        eps = advanceDays * 0.00001
-        elapsed_time = 0
+        self.curSimTime = solver.swmm_stride(advanceSeconds)
 
-        while self.curSimTime <= ctime + advanceDays - eps:
-            elapsed_time = solver.swmm_step()
-            if elapsed_time == 0:
-                return 0.0
-            self.curSimTime = elapsed_time
-
-        return elapsed_time
+        return self.curSimTime
 
     def swmm_report(self):
         """

--- a/pyswmm/tests/test_general_engine.py
+++ b/pyswmm/tests/test_general_engine.py
@@ -29,6 +29,22 @@ from pyswmm.swmm5 import PySWMM
 ##    sim = Simulation(MODEL_WEIR_SETTING_PATH)
 # print(sim.engine_version)
 
+def test_swmm_stride():
+    swmmobject = PySWMM(*get_model_files(MODEL_WEIR_SETTING_PATH))
+    swmmobject.swmm_open()
+    swmmobject.swmm_start()
+
+    i = 0
+    while (True):
+        time = swmmobject.swmm_stride(600)
+        i += 1
+
+        if i == 10:
+            break
+    print(time)
+    assert time == (600 * 10)/86400
+    swmmobject.swmm_end()
+    swmmobject.swmm_close()
 
 def test_runoff_error():
     sim = Simulation(MODEL_WEIR_SETTING_PATH)
@@ -50,17 +66,3 @@ def test_quality_error():
     print(sim.quality_error)
     assert sim.quality_error >= 0.0
 
-def test_swmm_stride():
-    swmmobject = PySWMM(*get_model_files(MODEL_WEIR_SETTING_PATH))
-    swmmobject.swmm_open()
-    swmmobject.swmm_start()
-
-    i = 0
-    while (True):
-        time = swmmobject.swmm_stride(600)
-        i += 1
-
-        if i == 10:
-            break
-    print(time)
-    assert time == (600 * 10)/86400

--- a/pyswmm/tests/test_general_engine.py
+++ b/pyswmm/tests/test_general_engine.py
@@ -12,8 +12,8 @@ import sys
 # Local imports
 from pyswmm import Simulation
 from pyswmm.tests.data import MODEL_WEIR_SETTING_PATH
-import pyswmm
-
+from pyswmm.utils.fixtures import get_model_files
+from pyswmm.swmm5 import PySWMM
 
 # def test_engine_version():
 # if sys.platform == 'darwin':
@@ -49,3 +49,18 @@ def test_quality_error():
     sim.execute()
     print(sim.quality_error)
     assert sim.quality_error >= 0.0
+
+def test_swmm_stride():
+    swmmobject = PySWMM(*get_model_files(MODEL_WEIR_SETTING_PATH))
+    swmmobject.swmm_open()
+    swmmobject.swmm_start()
+
+    i = 0
+    while (True):
+        time = swmmobject.swmm_stride(600)
+        i += 1
+
+        if i == 10:
+            break
+    print(time)
+    assert time == (600 * 10)/86400


### PR DESCRIPTION
Closes #500

This PR makes the default `PySWMM.swmm_stride()` method reference the c-code in `swmm.toolkit.solver.swmm_stride()`

However, if a user is using swmm_toolkit < 0.15.0, the old python implementation of swmm_stride is monkey patched into the PySWMM class, keeping this version of pyswmm backwards compatible with older versions of `swmm.toolkit`