### PR TITLE
Added patch to id search feature to remove exception

### DIFF
--- a/pyswmm/swmm5.py
+++ b/pyswmm/swmm5.py
@@ -558,7 +558,15 @@ class PySWMM(object):
 
     def ObjectIDexist(self, objecttype, ID):
         """Check if Object ID Exists. Mostly used as an internal function."""
-        index = solver.project_get_index(objecttype, ID)
+        # Incurred some micro-tech debt. This updated implementation will cover the before and after
+        # case of removing this line in SWMM.  Currently the SWMM function throws a non-zero error code. As
+        # a result, when it hit swmm-python(swmm-toolkit), it throws an exception.
+        # https://github.com/pyswmm/Stormwater-Management-Model/blob/459db1d4dfc61ff994ae01f92eae64e378e08915/src/solver/toolkit.c#L170
+        try:
+            # eventually this function will return -1 if the index does not exist.
+            index = solver.project_get_index(objecttype, ID)
+        except:
+            index = -1
 
         if index != -1:
             return True

--- a/pyswmm/tests/test_lid.py
+++ b/pyswmm/tests/test_lid.py
@@ -1,4 +1,5 @@
 # Local imports
+from swmm.toolkit.solver import lid_usage_get_flux_rate
 from pyswmm import Simulation
 from pyswmm import LidControls, LidGroups
 from pyswmm.tests.data import MODEL_LIDS_PATH
@@ -17,6 +18,7 @@ def test_list_lid_controls():
 
 def test_list_lid_groups():
     with Simulation(MODEL_LIDS_PATH) as sim:
+        assert "DUMMY_GROUP" not in LidGroups(sim)
         for i, group in enumerate(LidGroups(sim)):
             if i == 0:
                 assert('subcatchment {} has {} lid units'.format(group,

--- a/pyswmm/tests/test_links.py
+++ b/pyswmm/tests/test_links.py
@@ -31,6 +31,7 @@ def test_links_1():
 def test_links_2():
     with Simulation(MODEL_WEIR_SETTING_PATH) as sim:
         link_names = ["C1", "C1:C2", "C2", "C3"]
+        assert "DUMMY_LINK" not in Links(sim)
         for link in Links(sim):
             assert (link.linkid in link_names)
             link.flow_limit = 10

--- a/pyswmm/tests/test_nodes.py
+++ b/pyswmm/tests/test_nodes.py
@@ -30,6 +30,7 @@ def test_nodes_2():
     ''' pytest pyswmm/tests/test_nodes.py -k `test_nodes_2` '''
     with Simulation(MODEL_WEIR_SETTING_PATH) as sim:
         print("\n\n\nNODES\n")
+        assert "DUMMY_LINK" not in Nodes(sim)
         for node in Nodes(sim):
             assert ('J' in node.nodeid)
             node.invert_elevation = 10

--- a/pyswmm/tests/test_rainfallAPI.py
+++ b/pyswmm/tests/test_rainfallAPI.py
@@ -19,6 +19,7 @@ def test_api_rainfall():
 
 def test_rainfall():
     with Simulation(MODEL_RAIN) as sim:
+        assert "DUMMY_RG" not in RainGages(sim)
         rg = RainGages(sim)["Gage1"]
         assert(rg.raingageid == "Gage1")
 

--- a/pyswmm/tests/test_subcatchments.py
+++ b/pyswmm/tests/test_subcatchments.py
@@ -32,6 +32,7 @@ def test_subcatchments_1():
 
 def test_subcatchments_2():
     with Simulation(MODEL_WEIR_SETTING_PATH) as sim:
+        assert "DUMMY_SUBC" not in Subcatchments(sim)
         for subcatchment in Subcatchments(sim):
             print(subcatchment)
             print(subcatchment.subcatchmentid)


### PR DESCRIPTION
This is the patch for checking an id name in an object type.  Presently an exception is thrown if an ID is not contained therein.  The original intention of the feature was to return a True or False for existence.  True works! 

<img width="546" alt="IMG_0891" src="https://github.com/pyswmm/pyswmm/assets/6105134/848721ce-16d3-4983-ae47-160e267fa119">


The problem is actually this line in SWMM: https://github.com/pyswmm/Stormwater-Management-Model/blob/459db1d4dfc61ff994ae01f92eae64e378e08915/src/solver/toolkit.c#L170

Instead of monkey patching this, we might just keep the swmm5.ObjectIDexist() as is since my proposed implementation will cover the before and after cases of patching swmm.  I added a couple unit tests so we could watch the testing time go up 😂