### PR TITLE
added ctx mgr warning

### DIFF
--- a/pyswmm/simulation.py
+++ b/pyswmm/simulation.py
@@ -9,7 +9,6 @@
 
 # Standard import
 from warnings import warn
-from functools import wraps
 
 # Local imports
 from pyswmm.swmm5 import PySWMM, PYSWMMException

--- a/pyswmm/simulation.py
+++ b/pyswmm/simulation.py
@@ -84,8 +84,7 @@ class Simulation(object):
                  inputfile,
                  reportfile=None,
                  outputfile=None,
-                 sim_preconfig=None,
-                 suppress_context_warning=False):
+                 sim_preconfig=None):
         # sim_config enables a find/replace to be fun on the source input file
         # to create the new INP file.
         if sim_preconfig:

--- a/pyswmm/simulation.py
+++ b/pyswmm/simulation.py
@@ -9,11 +9,13 @@
 
 # Standard import
 from warnings import warn
+from functools import wraps
 
 # Local imports
 from pyswmm.swmm5 import PySWMM, PYSWMMException
 from pyswmm.toolkitapi import SimulationTime, SimulationUnits
 from pyswmm.errors import MultiSimulationError
+from pyswmm.warnings import SimulationContextWarning
 
 
 class _SimulationStateManager(object):
@@ -83,7 +85,8 @@ class Simulation(object):
                  inputfile,
                  reportfile=None,
                  outputfile=None,
-                 sim_preconfig=None):
+                 sim_preconfig=None,
+                 suppress_context_warning=False):
         # sim_config enables a find/replace to be fun on the source input file
         # to create the new INP file.
         if sim_preconfig:
@@ -115,6 +118,7 @@ class Simulation(object):
             "after_end": None,
             "after_close": None
         }
+        self._warn_context = True
 
     def __enter__(self):
         """
@@ -136,6 +140,7 @@ class Simulation(object):
             >>> 2015-11-01 14:02:00
 
         """
+        self._warn_context = False
         return self
 
     def __iter__(self):
@@ -144,6 +149,11 @@ class Simulation(object):
 
     def start(self):
         """Start Simulation (no longer suggested to user)."""
+        if self._warn_context:
+            # Emit warning if context manager is not used to instantiate Simulation
+            warn(SimulationContextWarning.message, SimulationContextWarning,
+                 stacklevel=2)
+            self._warn_context = False
         if not self._is_started:
             # Execute Callback Hooks Before Start
             self._execute_callback(self._before_start())
@@ -361,6 +371,12 @@ class Simulation(object):
             sim = Simulation('tests/data/model_weir_setting.inp')
             sim.execute()
         """
+        if self._warn_context:
+            # Emit warning if context manager is not used to instantiate the simulation
+            warn(
+                SimulationContextWarning.message, SimulationContextWarning, stacklevel=2
+            )
+            self._warn_context = False
         self._model.swmmExec()
         # swmm exec brings the simulation to a close therefore we
         # need to tell the sim state manager that we are free to

--- a/pyswmm/warnings.py
+++ b/pyswmm/warnings.py
@@ -5,7 +5,7 @@ class SimulationContextWarning(ResourceWarning):
         message -- explanation of the error
     """
     message = """
-    \tThe Simulation object is intended for use with the context
-    \tmanager. System resources will not be freed
-    \twithout calling close method. See Simulation docs for details.
+    \tThe Simulation object is intended to be used with a context
+    \tmanager. System resources will not be freed without calling 
+    \tthe close method. See Simulation class docs for details.
     """

--- a/pyswmm/warnings.py
+++ b/pyswmm/warnings.py
@@ -1,0 +1,11 @@
+class SimulationContextWarning(ResourceWarning):
+    """Warning raised for SWMM Simulation Context
+
+    Attributes:
+        message -- explanation of the error
+    """
+    message = """
+    \tThe Simulation object is intended for use with the context
+    \tmanager. System resources will not be freed
+    \twithout calling close method. See Simulation docs for details.
+    """


### PR DESCRIPTION
#529

The tactic I used adds the warning using a decorator to public methods. The decorator is removed (unwrapped) if the __enter__ method is called ie. a context manager is used.

Seems a bit hacky and maybe there's no 'good' way of doing this...


