### PR TITLE
Add 6 new smoke tests for Simulation and Output API

### DIFF
--- a/pyswmm/tests/test_context_protocol.py
+++ b/pyswmm/tests/test_context_protocol.py
@@ -1,0 +1,15 @@
+from pyswmm import Simulation, Output
+
+def test_simulation_context_protocol():
+    """Simulation should implement context manager protocol."""
+    assert hasattr(Simulation, "__enter__")
+    assert hasattr(Simulation, "__exit__")
+    assert callable(Simulation.__enter__)
+    assert callable(Simulation.__exit__)
+
+def test_output_context_protocol():
+    """Output should implement context manager protocol."""
+    assert hasattr(Output, "__enter__")
+    assert hasattr(Output, "__exit__")
+    assert callable(Output.__enter__)
+    assert callable(Output.__exit__)

--- a/pyswmm/tests/test_module_imports.py
+++ b/pyswmm/tests/test_module_imports.py
@@ -1,5 +1,6 @@
 import importlib
 
+
 def test_submodules_importable_without_side_effects():
     """Selected submodules should import without requiring SWMM runtime."""
     # These imports should not execute a simulation nor require binaries

--- a/pyswmm/tests/test_module_imports.py
+++ b/pyswmm/tests/test_module_imports.py
@@ -1,0 +1,8 @@
+import importlib
+
+def test_submodules_importable_without_side_effects():
+    """Selected submodules should import without requiring SWMM runtime."""
+    # These imports should not execute a simulation nor require binaries
+    for name in ("pyswmm.nodes", "pyswmm.links", "pyswmm.simulation", "pyswmm.output"):
+        mod = importlib.import_module(name)
+        assert mod is not None

--- a/pyswmm/tests/test_output_api.py
+++ b/pyswmm/tests/test_output_api.py
@@ -1,0 +1,41 @@
+# pyswmm/tests/test_output_api.py
+
+"""
+Smoke tests for pyswmm.Output that avoid touching the SWMM C layer.
+
+These tests intentionally DO NOT open any .out files, because the C extension
+(swmm.toolkit.output) may segfault when given invalid paths on some platforms.
+"""
+
+import importlib
+import inspect
+import types
+
+
+def test_output_symbol_is_exposed_and_is_class():
+    """Output should be importable from pyswmm and be a class/type."""
+    from pyswmm import Output  # noqa: F401
+    assert isinstance(Output, type)
+
+
+def test_output_module_import_has_no_runtime_side_effects():
+    """Importing pyswmm.output should succeed without running SWMM or touching files."""
+    mod = importlib.import_module("pyswmm.output")
+    assert isinstance(mod, types.ModuleType)
+    # basic sanity: the symbol is present on the module too
+    assert hasattr(mod, "Output")
+
+
+def test_output_has_context_protocol_methods_only():
+    """
+    Output should declare context manager hooks (__enter__/__exit__),
+    but we do not call them here (to avoid invoking the C backend).
+    """
+    from pyswmm import Output
+    assert hasattr(Output, "__enter__")
+    assert hasattr(Output, "__exit__")
+    assert callable(Output.__enter__)
+    assert callable(Output.__exit__)
+    # Additionally, make sure constructor is introspectable (no crash on inspect)
+    sig = inspect.signature(Output)
+    assert isinstance(sig, inspect.Signature)

--- a/pyswmm/tests/test_output_api.py
+++ b/pyswmm/tests/test_output_api.py
@@ -15,6 +15,7 @@ import types
 def test_output_symbol_is_exposed_and_is_class():
     """Output should be importable from pyswmm and be a class/type."""
     from pyswmm import Output  # noqa: F401
+
     assert isinstance(Output, type)
 
 
@@ -32,6 +33,7 @@ def test_output_has_context_protocol_methods_only():
     but we do not call them here (to avoid invoking the C backend).
     """
     from pyswmm import Output
+
     assert hasattr(Output, "__enter__")
     assert hasattr(Output, "__exit__")
     assert callable(Output.__enter__)

--- a/pyswmm/tests/test_public_api.py
+++ b/pyswmm/tests/test_public_api.py
@@ -1,0 +1,11 @@
+import re
+import pyswmm
+
+def test_public_imports_exist():
+    """Public API objects mentioned in docs should be importable."""
+    from pyswmm import Simulation, Nodes, Links, Output  # noqa: F401
+
+def test_version_semverish():
+    """__version__ should look like semantic versioning."""
+    ver = getattr(pyswmm, "__version__", "")
+    assert re.match(r"^\d+\.\d+\.\d+", str(ver)) is not None

--- a/pyswmm/tests/test_public_api.py
+++ b/pyswmm/tests/test_public_api.py
@@ -1,9 +1,11 @@
 import re
 import pyswmm
 
+
 def test_public_imports_exist():
     """Public API objects mentioned in docs should be importable."""
     from pyswmm import Simulation, Nodes, Links, Output  # noqa: F401
+
 
 def test_version_semverish():
     """__version__ should look like semantic versioning."""

--- a/pyswmm/tests/test_simulation_errors.py
+++ b/pyswmm/tests/test_simulation_errors.py
@@ -1,6 +1,7 @@
 import pytest
 from pyswmm import Simulation
 
+
 def test_simulation_missing_inp_raises():
     """Simulation should raise an Exception when .inp file is missing."""
     with pytest.raises(Exception) as excinfo:

--- a/pyswmm/tests/test_simulation_errors.py
+++ b/pyswmm/tests/test_simulation_errors.py
@@ -1,0 +1,10 @@
+import pytest
+from pyswmm import Simulation
+
+def test_simulation_missing_inp_raises():
+    """Simulation should raise an Exception when .inp file is missing."""
+    with pytest.raises(Exception) as excinfo:
+        with Simulation("this_file_definitely_does_not_exist.inp"):
+            pass
+    # optional: check error message for clarity
+    assert "cannot open input file" in str(excinfo.value).lower()

--- a/pyswmm/tests/test_typing_inputs.py
+++ b/pyswmm/tests/test_typing_inputs.py
@@ -1,6 +1,7 @@
 import pytest
 from pyswmm import Simulation, Output
 
+
 @pytest.mark.parametrize("cls", [Simulation])
 def test_path_argument_type_errors_simulation(cls):
     """Simulation should reject clearly invalid path-like argument types."""

--- a/pyswmm/tests/test_typing_inputs.py
+++ b/pyswmm/tests/test_typing_inputs.py
@@ -1,0 +1,8 @@
+import pytest
+from pyswmm import Simulation, Output
+
+@pytest.mark.parametrize("cls", [Simulation])
+def test_path_argument_type_errors_simulation(cls):
+    """Simulation should reject clearly invalid path-like argument types."""
+    with pytest.raises((TypeError, AttributeError, ValueError, Exception)):
+        cls(object())  # nonsense argument


### PR DESCRIPTION
This PR adds six small, safe smoke tests that run without SWMM input/output files:

- Simulation: raises an Exception when a non-existent .inp file is used
- Output: can be imported and exposes context manager methods (__enter__/__exit__)
- Public API: key classes (Simulation, Nodes, Links, Output) are importable
- Version: __version__ string follows a semantic-like pattern
- Submodules: core submodules import cleanly without runtime side effects
- Typing: Simulation constructor rejects clearly invalid path-like arguments

These tests extend coverage of error handling and public API surface
without invoking the SWMM solver or requiring data files.

Update:
- Applied code formatting using [black](https://black.readthedocs.io/en/stable/) for consistency.
- This commit contains no functional changes, only whitespace/formatting adjustments.
