### PR TITLE
Output: guard open() with a file-existence check to prevent segfaults

### DIFF
--- a/pyswmm/output.py
+++ b/pyswmm/output.py
@@ -10,6 +10,7 @@ from pyswmm.errors import OutputException
 from datetime import datetime, timedelta
 from functools import wraps
 from typing import NoReturn, Optional, Union
+from pathlib import Path
 
 # Third party imports
 from swmm.toolkit import output, shared_enum
@@ -171,6 +172,11 @@ class Output(object):
         :return: True if binary file was opened successfully
         :rtype: bool
         """
+        # Guard against missing path before allocating C handle
+        fp = Path(self.binfile)
+        if not fp.is_file():
+            raise OutputException(f"SWMM output file not found: {fp}")
+
         if self.handle is None:
             self.handle = output.init()
 

--- a/pyswmm/tests/test_output_missing_file.py
+++ b/pyswmm/tests/test_output_missing_file.py
@@ -1,0 +1,9 @@
+import pytest
+from pyswmm import Output
+from pyswmm.errors import OutputException
+
+def test_output_missing_file_raises_clean_error():
+    """Opening a non-existent .out should raise a Python exception (no segfault)."""
+    with pytest.raises(OutputException):
+        with Output("this_file_does_not_exist_123456.out"):
+            pass


### PR DESCRIPTION
This PR fixes a crash when attempting to open a non-existent SWMM `.out` file.

**Root cause**
- `Output.open()` directly called into the C layer (`swmm.toolkit.output.open`) even when the target file did not exist.
- On missing files, the C layer may segfault instead of raising a clean Python exception.
- Additionally, `output.init()` was being called before the file check, leaving behind an allocated Handle* when the open failed (reported as a SWIG leak).

**Fix**
- Add a Python-level existence check (`Path.is_file()`) before allocating the C handle.
- If the file does not exist, raise `OutputException` early, avoiding both segfaults and handle leaks.
- For valid files, behavior is unchanged.

**Tests**
- Added a regression test `test_output_missing_file.py` that ensures `Output("no_such.out")` raises `OutputException` instead of crashing.
- Verified that no SWIG warnings about leaked `Handle*` are emitted.

**How to run locally**
```bash
pip install pytest
python -m pytest -q pyswmm/tests/test_output_missing_file.py